### PR TITLE
feat: adding logging and EnableScheduling annotation to ScheduledTaskConfig

### DIFF
--- a/backend/src/main/java/com/bavis/budgetapp/config/ScheduledTasksConfig.java
+++ b/backend/src/main/java/com/bavis/budgetapp/config/ScheduledTasksConfig.java
@@ -1,7 +1,9 @@
 package com.bavis.budgetapp.config;
 
 import com.bavis.budgetapp.service.BudgetPerformanceService;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +12,8 @@ import org.springframework.stereotype.Component;
  *
  */
 @Component
+@Log4j2
+@EnableScheduling
 public class ScheduledTasksConfig {
 
     @Autowired
@@ -20,6 +24,7 @@ public class ScheduledTasksConfig {
      */
     @Scheduled(cron = "0 0 0 1 * ?")
     public void generateBudgetPerformance() {
+        log.info("Executing monthly Budget Performance job");
         budgetPerformanceService.runGenerateBudgetPerformanceJob(null);
     }
 }


### PR DESCRIPTION
Adding logging and the @EnableScheduling to the ScheduledTasksConfig. 

This is being implemented to debug issue with ScheduledJob not being run on the first of the month (9/01/2024). 