### PR TITLE
Fix Transaction Sync Flow (Posted vs Pending Transaction States) 

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,5 +1,6 @@
 application.properties
 application.yaml
+application-test.yaml
 .env
 /.gradle/
 .gradle/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,6 +1,6 @@
 application.properties
 application.yaml
-application-test.yaml
+**/application-test.yaml
 .env
 /.gradle/
 .gradle/

--- a/backend/src/main/java/com/bavis/budgetapp/dao/TransactionRepository.java
+++ b/backend/src/main/java/com/bavis/budgetapp/dao/TransactionRepository.java
@@ -26,7 +26,7 @@ public interface TransactionRepository extends JpaRepository<Transaction, String
      *          - all Transactions corresponding to current year/month and specified Account IDss
      */
 
-    @Query("SELECT t FROM Transaction t WHERE t.account.accountId IN :accountIds AND (t.date IS NOT NULL AND EXTRACT(MONTH FROM CAST(t.date AS date)) = EXTRACT(MONTH FROM CAST(:currentDate AS date)) AND EXTRACT(YEAR FROM CAST(t.date AS date)) = EXTRACT(YEAR FROM CAST(:currentDate AS date)))")
+    @Query("SELECT t FROM Transaction t WHERE t.account.accountId IN :accountIds AND t.isDeleted IS FALSE AND (t.date IS NOT NULL AND EXTRACT(MONTH FROM CAST(t.date AS date)) = EXTRACT(MONTH FROM CAST(:currentDate AS date)) AND EXTRACT(YEAR FROM CAST(t.date AS date)) = EXTRACT(YEAR FROM CAST(:currentDate AS date)))")
     List<Transaction> findByAccountIdsAndCurrentMonth(@Param("accountIds") List<String> accountIds, @Param("currentDate") LocalDate currentDate);
 
     /**

--- a/backend/src/main/java/com/bavis/budgetapp/dto/PlaidTransactionDto.java
+++ b/backend/src/main/java/com/bavis/budgetapp/dto/PlaidTransactionDto.java
@@ -37,6 +37,9 @@ public class PlaidTransactionDto {
 
     private PersonalFinanceCategoryDto personal_finance_category;
 
+    private String pending_transaction_id;
+    private boolean pending;
+
     @Data
     @NoArgsConstructor
     @AllArgsConstructor

--- a/backend/src/main/java/com/bavis/budgetapp/entity/Transaction.java
+++ b/backend/src/main/java/com/bavis/budgetapp/entity/Transaction.java
@@ -28,6 +28,9 @@ public class Transaction {
 	private LocalDate date;
 	private String logoUrl;
 
+	@Column(name = "is_deleted", columnDefinition = "boolean default false")
+	private boolean isDeleted;
+
 	@Column(name = "updated_by_user", columnDefinition = "boolean default false")
 	private boolean updatedByUser;
 

--- a/backend/src/main/java/com/bavis/budgetapp/filter/TransactionFilters.java
+++ b/backend/src/main/java/com/bavis/budgetapp/filter/TransactionFilters.java
@@ -1,0 +1,124 @@
+package com.bavis.budgetapp.filter;
+
+import com.bavis.budgetapp.dao.TransactionRepository;
+import com.bavis.budgetapp.dto.PlaidTransactionDto;
+import com.bavis.budgetapp.entity.Transaction;
+import com.bavis.budgetapp.util.GeneralUtil;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class TransactionFilters {
+
+    private final TransactionRepository transactionRepository;
+
+
+    /**
+     * Generic Filters used by each group
+     */
+    private static final Predicate<Transaction> HAS_POSITIVE_AMOUNT =
+            transaction -> transaction.getAmount() > 0;
+
+
+    private static final Predicate<Transaction> IS_CURRENT_MONTH =
+            transaction -> GeneralUtil.isDateInCurrentMonth(transaction.getDate());
+
+
+    private static final Predicate<Transaction> IS_PREVIOUS_MONTH =
+            transaction -> GeneralUtil.isDateInPreviousMonth(transaction.getDate());
+
+    private static final Predicate<Transaction> IS_NOT_DELETED =
+            transaction -> !transaction.isDeleted();
+
+    private Predicate<Transaction> alreadyExists() {
+        return transaction -> transactionRepository.existsById(transaction.getTransactionId());
+    }
+
+    private Predicate<Transaction> alreadyExistsAndUpdatedByUser() {
+        return transaction -> !transactionRepository.existsByTransactionIdAndUpdatedByUserIsTrue(transaction.getTransactionId());
+    }
+
+
+    /**
+     * Filter to ensure that we have not already previously account for this transaction
+     *
+     * @param prevMonthTransactions
+     *          - previous month transactions already accounted for
+     */
+    private Predicate<Transaction> notAlreadyAccountedFor(List<Transaction> prevMonthTransactions) {
+        Set<String> existingIds = prevMonthTransactions.stream()
+                .map(Transaction::getTransactionId)
+                .collect(Collectors.toSet());
+
+        return transaction -> !existingIds.contains(transaction.getTransactionId());
+    }
+
+    /***
+     * Filter group for previous month transactions
+     *
+     * @param previousMonthTransactions
+     *          - previous month transactions that have already been accounted for
+     */
+    public Predicate<Transaction> prevMonthTransactionFilters(List<Transaction> previousMonthTransactions) {
+        return HAS_POSITIVE_AMOUNT
+                .and(IS_PREVIOUS_MONTH)
+                .and(IS_NOT_DELETED)
+                .and(notAlreadyAccountedFor(previousMonthTransactions));
+    }
+
+    /**
+     * Filter group for modified transactions
+     */
+    public Predicate<Transaction> modifiedTransactionFilters() {
+        return HAS_POSITIVE_AMOUNT
+                .and(IS_CURRENT_MONTH)
+                .and(IS_NOT_DELETED)
+                .and(alreadyExists())
+                .and(alreadyExistsAndUpdatedByUser());
+    }
+
+    /**
+     * Filter group for added transactions
+     */
+    public Predicate<Transaction> addedTransactionFilters() {
+        return HAS_POSITIVE_AMOUNT
+                .and(IS_CURRENT_MONTH);
+    }
+
+
+    /**
+     * Filtering to account for pending/posted transactions that a user may have already updated
+     */
+    public Predicate<PlaidTransactionDto> isPendingAndUserModified(Set<String> pendingTransactionIds) {
+        return plaidTransactionDto -> {
+            String pendingTransactionId = plaidTransactionDto.getPending_transaction_id();
+
+            // if the transaction doesn't corresponding to pending transaction, then we should not filter out
+            if (StringUtils.isEmpty(pendingTransactionId)) {
+                return true;
+            }
+
+            // check if we have modified the transaction
+            Transaction persistedTransaction = transactionRepository.findById(pendingTransactionId).orElse(null);
+            if (persistedTransaction == null) {
+                return true; //transaction isn't persisted, so we should not filter out
+            }
+
+            // filter out transaction if it was updated by user
+            if (persistedTransaction.isUpdatedByUser()){
+                // add transaction ID in order to account for this in removedTransactions filter later on
+                pendingTransactionIds.add(pendingTransactionId);
+                return false;
+            }
+            return true;
+        };
+    }
+
+}

--- a/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
+++ b/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
@@ -61,6 +61,8 @@ public class TransactionServiceImpl implements TransactionService {
         List<String> allRemovedTransactionIds = new ArrayList<>();
         List<Transaction> previousMonthTransactions = new ArrayList<>();
 
+        Set<String> pendingTransactionIds = new HashSet<>();
+
         boolean hasMore;
         boolean updateOriginalCursor;
         String accessToken;
@@ -88,7 +90,7 @@ public class TransactionServiceImpl implements TransactionService {
                     log.info("PlaidTransactionSyncResponseDto for Account ID {} : [{}]", accountId, syncResponseDto);
 
                     //Collect Added Transactions
-                    allModifiedOrAddedTransactions.addAll(mapAddedTransactions(syncResponseDto.getAdded(), account));
+                    allModifiedOrAddedTransactions.addAll(mapAddedTransactions(syncResponseDto.getAdded(), account, pendingTransactionIds));
 
                     //Collect Modified Transactions
                     allModifiedOrAddedTransactions.addAll(mapModifiedTransactions(syncResponseDto.getModified(), account));
@@ -135,7 +137,15 @@ public class TransactionServiceImpl implements TransactionService {
         //Persist updates
         if(!allModifiedOrAddedTransactions.isEmpty()) _transactionRepository.saveAllAndFlush(allModifiedOrAddedTransactions);
         if(!previousMonthTransactions.isEmpty()) _transactionRepository.saveAllAndFlush(previousMonthTransactions);
-        if(!allRemovedTransactionIds.isEmpty()) _transactionRepository.deleteAllById(allRemovedTransactionIds);
+        if(!allRemovedTransactionIds.isEmpty()) {
+
+            //filter out transaction ids that correspond to user modified transactions (Plaid will remove previously pending transactions that are now finalized, but we don't want the user to need to re-allocate/assign transactions each time)
+            List<String> filteredTransactionIds = allRemovedTransactionIds.stream()
+                    .filter(transactionId -> !pendingTransactionIds.contains(transactionId))
+                    .toList();
+
+            if(!filteredTransactionIds.isEmpty())  _transactionRepository.deleteAllById(filteredTransactionIds);
+        }
 
         //Return DTO
         return SyncTransactionsDto.builder()
@@ -344,7 +354,7 @@ public class TransactionServiceImpl implements TransactionService {
      * @return
      *          - Transaction entities to be persisted
      */
-    private List<Transaction> mapAddedTransactions(List<PlaidTransactionDto> addedPlaidTransactions, Account account) {
+    private List<Transaction> mapAddedTransactions(List<PlaidTransactionDto> addedPlaidTransactions, Account account, Set<String> pendingTransactionIds) {
 
         List<Transaction> addedTransactionEntities = Optional.ofNullable(addedPlaidTransactions).stream().flatMap(List::stream)
                 .filter(_transactionFilters.isPendingAndUserModified(pendingTransactionIds)) //filter out plaid transactions that have been modfiied by user

--- a/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
+++ b/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
@@ -395,8 +395,8 @@ public class TransactionServiceImpl implements TransactionService {
                 .map(_transactionMapper::toEntity)
                 .filter(_transactionFilters.modifiedTransactionFilters())
                 .peek(transaction -> {
-                    //TODO: Intelligently assign CategoryType & Category in future
-                    transaction.setCategory(null);
+                    Transaction persistedTransaction = readById(transaction.getTransactionId());
+                    transaction.setCategory(persistedTransaction.getCategory());  // set category to modified transactions current category
                     transaction.setAccount(account);
                 })
                 .toList();

--- a/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
+++ b/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
@@ -137,10 +137,12 @@ public class TransactionServiceImpl implements TransactionService {
         //Persist updates
         if(!allModifiedOrAddedTransactions.isEmpty()) _transactionRepository.saveAllAndFlush(allModifiedOrAddedTransactions);
         if(!previousMonthTransactions.isEmpty()) _transactionRepository.saveAllAndFlush(previousMonthTransactions);
+
+        List<String> filteredTransactionIds = new ArrayList<>();
         if(!allRemovedTransactionIds.isEmpty()) {
 
             //filter out transaction ids that correspond to user modified transactions (Plaid will remove previously pending transactions that are now finalized, but we don't want the user to need to re-allocate/assign transactions each time)
-            List<String> filteredTransactionIds = allRemovedTransactionIds.stream()
+            filteredTransactionIds = allRemovedTransactionIds.stream()
                     .filter(transactionId -> !pendingTransactionIds.contains(transactionId))
                     .toList();
 
@@ -150,7 +152,7 @@ public class TransactionServiceImpl implements TransactionService {
         //Return DTO
         return SyncTransactionsDto.builder()
                 .allModifiedOrAddedTransactions(allModifiedOrAddedTransactions)
-                .removedTransactionIds(allRemovedTransactionIds)
+                .removedTransactionIds(filteredTransactionIds)
                 .previousMonthTransactions(previousMonthTransactions)
                 .build();
     }

--- a/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
+++ b/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
@@ -358,7 +358,6 @@ public class TransactionServiceImpl implements TransactionService {
      *          - Transaction entities to be persisted
      */
     private List<Transaction> mapAddedTransactions(List<PlaidTransactionDto> addedPlaidTransactions, Account account, Set<String> pendingTransactionIds) {
-
         List<Transaction> addedTransactionEntities = Optional.ofNullable(addedPlaidTransactions).stream().flatMap(List::stream)
                 .filter(_transactionFilters.isPendingAndUserModified(pendingTransactionIds)) //filter out plaid transactions that have been modfiied by user
                 .map(_transactionMapper::toEntity)
@@ -389,7 +388,6 @@ public class TransactionServiceImpl implements TransactionService {
      *          - Transaction entities to be persisted
      */
     private List<Transaction> mapModifiedTransactions(List<PlaidTransactionDto> modifiedPlaidTransactions, Account account) {
-
         List<Transaction> modifiedTransactionEntities = Optional.ofNullable(modifiedPlaidTransactions).stream().flatMap(List::stream)
                 .map(_transactionMapper::toEntity)
                 .filter(_transactionFilters.modifiedTransactionFilters())

--- a/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
+++ b/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
@@ -336,9 +336,6 @@ public class TransactionServiceImpl implements TransactionService {
         // soft delete the transaction
         transaction.setDeleted(true);
         _transactionRepository.save(transaction);
-
-        //Delete
-        _transactionRepository.delete(transaction);
     }
 
     @Override

--- a/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
+++ b/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
@@ -135,8 +135,17 @@ public class TransactionServiceImpl implements TransactionService {
         }
 
         //Persist updates
+        if(!previousMonthTransactions.isEmpty()) {
+            // save previous month transactions
+            _transactionRepository.saveAllAndFlush(previousMonthTransactions);
+
+            // filter out previous month transactions from all added/modified
+            Set<String> previousMonthTransactionIds = previousMonthTransactions.stream().map(Transaction::getTransactionId).collect(Collectors.toSet());
+            allModifiedOrAddedTransactions = allModifiedOrAddedTransactions.stream()
+                    .filter(t -> !previousMonthTransactionIds.contains(t.getTransactionId()))
+                    .toList();
+        }
         if(!allModifiedOrAddedTransactions.isEmpty()) _transactionRepository.saveAllAndFlush(allModifiedOrAddedTransactions);
-        if(!previousMonthTransactions.isEmpty()) _transactionRepository.saveAllAndFlush(previousMonthTransactions);
 
         List<String> filteredTransactionIds = new ArrayList<>();
         if(!allRemovedTransactionIds.isEmpty()) {

--- a/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
+++ b/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
@@ -333,6 +333,10 @@ public class TransactionServiceImpl implements TransactionService {
         //Fetch Transaction, or Throw Exception if Not Found
         Transaction transaction = readById(transactionId);
 
+        // soft delete the transaction
+        transaction.setDeleted(true);
+        _transactionRepository.save(transaction);
+
         //Delete
         _transactionRepository.delete(transaction);
     }

--- a/backend/src/test/java/com/bavis/budgetapp/filter/JwtAuthFilterTests.java
+++ b/backend/src/test/java/com/bavis/budgetapp/filter/JwtAuthFilterTests.java
@@ -1,9 +1,8 @@
-package com.bavis.budgetapp.jwt;
+package com.bavis.budgetapp.filter;
 
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.bavis.budgetapp.constants.Role;
-import com.bavis.budgetapp.filter.JwtAuthenticationFilter;
 import com.bavis.budgetapp.TestHelper;
 import com.bavis.budgetapp.entity.User;
 import com.bavis.budgetapp.service.JwtService;

--- a/backend/src/test/java/com/bavis/budgetapp/filter/TransactionFilterTests.java
+++ b/backend/src/test/java/com/bavis/budgetapp/filter/TransactionFilterTests.java
@@ -1,0 +1,209 @@
+package com.bavis.budgetapp.filter;
+
+import com.bavis.budgetapp.dao.TransactionRepository;
+import com.bavis.budgetapp.dto.PlaidTransactionDto;
+import com.bavis.budgetapp.entity.Transaction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles(profiles = "test")
+public class TransactionFilterTests {
+
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @InjectMocks
+    private TransactionFilters transactionFilters;
+
+    private Transaction sampleTransaction;
+
+    @BeforeEach
+    void setUp() {
+        sampleTransaction = new Transaction();
+        sampleTransaction.setTransactionId("tx123");
+        sampleTransaction.setAmount(100.0);
+        sampleTransaction.setDate(LocalDate.now());
+        sampleTransaction.setDeleted(false);
+        sampleTransaction.setUpdatedByUser(false);
+    }
+
+    @Test
+    void testPrevMonthTransactionFilters_shouldPass() {
+        sampleTransaction.setDate(LocalDate.now().minusMonths(1));
+
+        List<Transaction> accounted = new ArrayList<>();
+        boolean result = transactionFilters.prevMonthTransactionFilters(accounted).test(sampleTransaction);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void testPrevMonthTransactionFilters_shouldFail_ifDeleted() {
+        sampleTransaction.setDate(LocalDate.now().minusMonths(1));
+        sampleTransaction.setDeleted(true);
+
+        boolean result = transactionFilters.prevMonthTransactionFilters(Collections.emptyList()).test(sampleTransaction);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testPrevMonthTransactionFilters_shouldFail_ifAlreadyAccounted() {
+        Transaction existing = new Transaction();
+        existing.setTransactionId("tx123");
+
+        List<Transaction> accounted = List.of(existing);
+
+        sampleTransaction.setDate(LocalDate.now().minusMonths(1));
+
+        boolean result = transactionFilters.prevMonthTransactionFilters(accounted).test(sampleTransaction);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testModifiedTransactionFilters_shouldPass() {
+        sampleTransaction.setUpdatedByUser(false);
+        when(transactionRepository.existsById("tx123")).thenReturn(true);
+        when(transactionRepository.existsByTransactionIdAndUpdatedByUserIsTrue("tx123")).thenReturn(false);
+
+        boolean result = transactionFilters.modifiedTransactionFilters().test(sampleTransaction);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void testModifiedTransactionFilters_shouldFail_notCurrentMonth() {
+        sampleTransaction.setDate(LocalDate.now().minusMonths(1));
+
+        boolean result = transactionFilters.modifiedTransactionFilters().test(sampleTransaction);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testModifiedTransactionFilters_shouldFail_ifNotExists() {
+        when(transactionRepository.existsById("tx123")).thenReturn(false);
+
+        boolean result = transactionFilters.modifiedTransactionFilters().test(sampleTransaction);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testModifiedTransactionFilters_shouldFail_ifUpdatedByUser() {
+        when(transactionRepository.existsById("tx123")).thenReturn(true);
+        when(transactionRepository.existsByTransactionIdAndUpdatedByUserIsTrue("tx123")).thenReturn(true);
+
+        boolean result = transactionFilters.modifiedTransactionFilters().test(sampleTransaction);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testModifiedTransactionFilters_shouldFail_ifDeleted() {
+        sampleTransaction.setDeleted(true);
+
+        boolean result = transactionFilters.modifiedTransactionFilters().test(sampleTransaction);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testModifiedTransactionFilters_shouldFail_ifNegativeAmount() {
+        sampleTransaction.setAmount(-50.0);
+
+        boolean result = transactionFilters.modifiedTransactionFilters().test(sampleTransaction);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testAddedTransactionFilters_shouldPass_forPositiveCurrentMonthTransaction() {
+        boolean result = transactionFilters.addedTransactionFilters().test(sampleTransaction);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void testAddedTransactionFilters_shouldFail_ifNegativeAmount() {
+        sampleTransaction.setAmount(-50.0);
+
+        boolean result = transactionFilters.addedTransactionFilters().test(sampleTransaction);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testAddedTransactionFilters_shouldFail_ifNotCurrentMonth() {
+        sampleTransaction.setDate(LocalDate.now().minusMonths(1));
+        boolean result = transactionFilters.addedTransactionFilters().test(sampleTransaction);
+        assertFalse(result);
+    }
+
+    @Test
+    void testIsPendingAndUserModified_shouldPass_ifNoPendingId() {
+        PlaidTransactionDto dto = new PlaidTransactionDto();
+        dto.setPending_transaction_id(null);
+
+        boolean result = transactionFilters.isPendingAndUserModified(new HashSet<>()).test(dto);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsPendingAndUserModified_shouldPass_ifTransactionNotPersisted() {
+        PlaidTransactionDto dto = new PlaidTransactionDto();
+        dto.setPending_transaction_id("pending123");
+
+        when(transactionRepository.findById("pending123")).thenReturn(Optional.empty());
+
+        boolean result = transactionFilters.isPendingAndUserModified(new HashSet<>()).test(dto);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsPendingAndUserModified_shouldFail_ifUpdatedByUser() {
+        Transaction updated = new Transaction();
+        updated.setUpdatedByUser(true);
+
+        PlaidTransactionDto dto = new PlaidTransactionDto();
+        dto.setPending_transaction_id("pending123");
+
+        when(transactionRepository.findById("pending123")).thenReturn(Optional.of(updated));
+
+        Set<String> filtered = new HashSet<>();
+        boolean result = transactionFilters.isPendingAndUserModified(filtered).test(dto);
+
+        assertFalse(result);
+        assertTrue(filtered.contains("pending123"));
+    }
+
+    @Test
+    void testIsPendingAndUserModified_shouldPass_ifNotUpdatedByUser() {
+        Transaction notUpdated = new Transaction();
+        notUpdated.setUpdatedByUser(false);
+
+        PlaidTransactionDto dto = new PlaidTransactionDto();
+        dto.setPending_transaction_id("pending456");
+
+        when(transactionRepository.findById("pending456")).thenReturn(Optional.of(notUpdated));
+
+        boolean result = transactionFilters.isPendingAndUserModified(new HashSet<>()).test(dto);
+
+        assertTrue(result);
+    }
+}

--- a/backend/src/test/java/com/bavis/budgetapp/services/JwtServiceTests.java
+++ b/backend/src/test/java/com/bavis/budgetapp/services/JwtServiceTests.java
@@ -1,4 +1,4 @@
-package com.bavis.budgetapp.jwt;
+package com.bavis.budgetapp.services;
 
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;


### PR DESCRIPTION
This PR introduces some necessary updates and refactorings to the logic surrounding our transaction sync flow. The main reasoning behind the need for this PR is to try and avoid having a user need to re-assign / re-allocate / re-name, etc any transaction that they may have already updated.

Plaid API has two separate states for transactions: 1) posted, or 2) pending. This logic caused for a user to need to re-do certain operations to their transactions despite either a) already completing this, or b) deleted the transaction altogether. 

Main Changes

1. Soft deletion of transactions from our database 
2. Accounting for a pending transaction being changed into a posted transaction 