### PR TITLE
fix: update relative dir

### DIFF
--- a/frontend/docker/Dockerfile
+++ b/frontend/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 # production stage
 FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
-COPY ../nginx/nginx.config /etc/nginx/nginx.conf 
+COPY nginx/nginx.config /etc/nginx/nginx.conf 
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/docker/Dockerfile
+++ b/frontend/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 # production stage
 FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
-COPY nginx/nginx.config /etc/nginx/nginx.conf 
+COPY nginx/nginx.conf /etc/nginx/nginx.conf 
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
build context is within frontned, so no need to navigate out of current directory when copying