### PR TITLE
Resolve Docker Dependency Issue

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,39 @@
+# Dependencies
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Production build
+build
+dist
+
+# Environment files
+.env
+
+# IDE and editor files
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+
+# Git
+.git
+.gitignore
+
+# Documentation
+README.md
+*.md
+
+# Cache directories
+.cache
+.parcel-cache
+
+# Logs
+logs
+*.log

--- a/frontend/docker/Dockerfile
+++ b/frontend/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14-alpine AS build
 
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm ci --only-production
+RUN npm ci
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
Account for essential dependencies that are considered "dev" but are required. 

Add .dockerignore file to reduce build context size. 