### PR TITLE
fix: account for dev dependencies

### DIFF
--- a/frontend/docker/Dockerfile
+++ b/frontend/docker/Dockerfile
@@ -1,9 +1,10 @@
 # build react application
 FROM node:22.1.0-alpine AS build
-
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm ci
+
+RUN npm ci --include=dev
+
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
TailwindCSS is configured as a dev dependency. In order for nginx to serve out static files with CSS applied, we need to update our npm ci command to account for these dependencies 