### PR TITLE
Soft Deletion of an Account

### DIFF
--- a/backend/src/main/java/com/bavis/budgetapp/entity/Account.java
+++ b/backend/src/main/java/com/bavis/budgetapp/entity/Account.java
@@ -44,4 +44,7 @@ public class Account {
 	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
 	@JoinColumn(name = "connectionId", referencedColumnName = "connectionId")
 	private Connection connection;
+
+	@Column(name = "is_deleted", columnDefinition = "boolean default false")
+	private boolean isDeleted;
 }

--- a/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
+++ b/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
@@ -171,18 +171,20 @@ public class TransactionServiceImpl implements TransactionService {
         log.info("Attempting to read all Transaction entities corresponding to authenticated user's added Accounts and the current month");
         User currentAuthUser = _userService.getCurrentAuthUser();
         LocalDate currentDate = LocalDate.now();
-        List<Account> accounts = currentAuthUser.getAccounts();
+        List<Account> accounts = currentAuthUser.getAccounts().stream()
+                .filter(account -> !account.isDeleted())
+                .toList();
         List<Category> categories = currentAuthUser.getCategories();
         List<Transaction> allUserTransactions = new ArrayList<>(); //transactions to return
 
         //Validate User Has Accounts To Fetch Transactions For
-        if(accounts == null && categories == null) {
+        if(accounts.isEmpty() && categories == null) {
             return new ArrayList<>();
         }
 
 
         //Fetch All Transactions associated with User Accounts if user has added Accounts
-        if(accounts != null) {
+        if(!accounts.isEmpty()) {
             List<String> accountIds = accounts.stream()
                     .map(Account::getAccountId)
                     .collect(Collectors.toList());

--- a/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
+++ b/backend/src/main/java/com/bavis/budgetapp/service/impl/TransactionServiceImpl.java
@@ -171,8 +171,10 @@ public class TransactionServiceImpl implements TransactionService {
         log.info("Attempting to read all Transaction entities corresponding to authenticated user's added Accounts and the current month");
         User currentAuthUser = _userService.getCurrentAuthUser();
         LocalDate currentDate = LocalDate.now();
-        List<Account> accounts = currentAuthUser.getAccounts().stream()
-                .filter(account -> !account.isDeleted())
+        List<Account> accounts = Optional.ofNullable(currentAuthUser.getAccounts())
+                .orElseGet(List::of)
+                .stream()
+                .filter(account -> account != null && !account.isDeleted())
                 .toList();
         List<Category> categories = currentAuthUser.getCategories();
         List<Transaction> allUserTransactions = new ArrayList<>(); //transactions to return


### PR DESCRIPTION
Instead of deleting an account from our database, we will soft delete the account in order to preserve the existing transactions associated with the deleted account. 

On top of this, retrieval of accounts will not filter out these deleted accounts. 