### PR TITLE
fix: allow for iteration through transactions

### DIFF
--- a/frontend/src/components/transaction/PreviousTransactionsModal.js
+++ b/frontend/src/components/transaction/PreviousTransactionsModal.js
@@ -27,6 +27,17 @@ const PreviousTransactionsModal = ({
   const [displayName, setDisplayName] = useState(transaction.name);
   const [displayAmount, setDisplayAmount] = useState(transaction.amount);
 
+  useEffect(() => {
+    if (transaction) {
+      setEditedName(transaction.name);
+      setEditedAmount(transaction.amount);
+      setDisplayName(transaction.name);
+      setDisplayAmount(transaction.amount);
+      setIsEditingName(false);
+      setIsEditingAmount(false);
+    }
+  }, [transaction]);
+
   const handleCategorySelect = (category) => {
     setSelectedCategory(category);
     setConfirmationVisible(true);


### PR DESCRIPTION
The following code ensures that the displayed transaction is conveyed after the user has assigned their transaction to a category 