### PR TITLE
Multi-Stage Dockerfile & Utilization of .dockerignore File 

### DIFF
--- a/backend/suggestion_engine/docker/.dockerignore
+++ b/backend/suggestion_engine/docker/.dockerignore
@@ -1,0 +1,40 @@
+# Python bytecode and cache
+__pycache__/
+*.py[cod]
+*.pyc
+
+# Virtual environments  
+.venv/
+venv/
+.env
+
+# IDE files
+.vscode/
+.idea/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+
+# Docker files
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+
+# Documentation
+README.md
+*.md
+
+# Large model files 
+*.pth
+*.pt
+*.pkl
+
+# Logs and temp
+*.log
+tmp/
+temp/

--- a/backend/suggestion_engine/docker/Dockerfile
+++ b/backend/suggestion_engine/docker/Dockerfile
@@ -1,17 +1,37 @@
-FROM python:3.11-slim
+# build stage
+FROM python:3.11-slim as builder
 
-WORKDIR /app
+# avoid bytecode generation, enforce stdout/stderr to be unbuffered, no cache dir when installing pckgs, disbale automatic version checks
+ENV PYTHONDONTWRITEBYTECODE=1 \ 
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# avoid bytecode being written to disk, force python to output to stdout
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+# change to build dir
+WORKDIR /build
 
+# copy & install necessary deps
 COPY requirements.txt .
+RUN pip install --user --no-warn-script-location -r requirements.txt
 
-RUN pip install --no-cache-dir -r requirements.txt
 
+# production stage 
+FROM python:3.11-slim as production
+
+# avoid bytecode generation, enforce stdout/stdder to be unbuffered, update PATH variable, indicate to Python interpreter where to look for moudle
+ENV PYTHONDONTWRITEBYTECODE=1 \ 
+    PYTHONUNBUFFERED=1 \
+    PATH="/root/.local/bin:$PATH" \
+    PYTHONPATH="/app"
+
+# copy Python packages from builder stage
+COPY --from=builder /root/.local /root/.local
+
+# copy code
 COPY . .
 
+# expose relevant port 
 EXPOSE 8000
 
+# run service
 CMD ["uvicorn", "service:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
The following PR aims to reduce the amount of unnecessary bloat we are storing within our final built docker image, with the intention of reducing the size and build times. As of now, we are running into an issue with the inability to pull suggestion engine docker image when running our docker compose file due to lack of disk space required for PyTorch. These updates likely are a stepping stone in the right direction, but an additional PR to address the bloat caused by PyTorch will be follow on to this one. 