### PR TITLE
Fix Relative Directory Issues While Building Suggestion Engine Docker Image

### DIFF
--- a/backend/jenkins/Jenkinsfile
+++ b/backend/jenkins/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
                 dir('backend') {
                     script {
                         def imageVersion = env.VERSION
-                        bat "docker build -t budget-app-suggestion-engine:${imageVersion} -f suggestion-engine/docker/Dockerfile ."
+                        bat "docker build -t budget-app-suggestion-engine:${imageVersion} -f suggestion_engine/docker/Dockerfile ."
                     }
                 }
             }

--- a/backend/jenkins/Jenkinsfile
+++ b/backend/jenkins/Jenkinsfile
@@ -57,10 +57,10 @@ pipeline {
 
         stage('Build Suggestion Engine Docker Image') {
             steps {
-                dir('backend/suggestion_engine') {
+                dir('backend') {
                     script {
                         def imageVersion = env.VERSION
-                        bat "docker build -t budget-app-suggestion-engine:${imageVersion} -f docker/Dockerfile ."
+                        bat "docker build -t budget-app-suggestion-engine:${imageVersion} -f suggestion-engine/docker/Dockerfile ."
                     }
                 }
             }

--- a/backend/suggestion_engine/docker/Dockerfile
+++ b/backend/suggestion_engine/docker/Dockerfile
@@ -24,14 +24,18 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PATH="/root/.local/bin:$PATH" \
     PYTHONPATH="/app"
 
+
+# update working directory 
+WORKDIR /app
+
 # copy Python packages from builder stage
 COPY --from=builder /root/.local /root/.local
 
 # copy code
-COPY . .
+COPY . /app
 
 # expose relevant port 
 EXPOSE 8000
 
 # run service
-CMD ["uvicorn", "service:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "suggestion_engine.service:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
The following PR implements the fix necessary to ensure imports made in our Python files are correct based on relative directory during the building of our Docker Image. Instead of building the Docker Image while within the suggestion-engine/ directory, we should run this from the backend/ directory, ensuring the imports are correct. 