### PR TITLE
Fix Cache Eviction Policy for ONNX Models

### DIFF
--- a/backend/suggestion_engine/inference/models/manager.py
+++ b/backend/suggestion_engine/inference/models/manager.py
@@ -2,6 +2,7 @@ import gc
 from pathlib import Path
 import json
 import onnxruntime as ort
+from datetime import datetime, time
 
 class ModelManager:
 
@@ -9,9 +10,13 @@ class ModelManager:
         self._user_models = {} 
         self._max_capacity = 2
         self.model_accuracy = {}
+        self._cache_date = {}
     
 
     def get_model(self, user_id):
+
+        # clear cache if necessary 
+        self.clear_cache(user_id)
 
         # return model if already in memory 
         if user_id in self._user_models:
@@ -21,6 +26,7 @@ class ModelManager:
         if len(self._user_models) > self._max_capacity:
             self._user_models.clear()
             self.model_accuracy.clear()
+            self._cache_date.clear()
             gc.collect()
 
         
@@ -37,10 +43,50 @@ class ModelManager:
 
         self._user_models[user_id] = onnx_model
         self.model_accuracy[user_id] = meta_data['accuracy']
+        self._cache_date[user_id] = datetime.now().date()
 
         gc.collect() # force garabge collection
 
         return onnx_model
+    
+
+    def is_cache_stale(self, user_id):
+        """
+        Helper function to determine if the cache is stale corresponding to a user 
+        """
+        if user_id not in self._cache_date:
+            return True 
+
+        now = datetime.now() 
+        cache_date = self._cache_date[user_id]
+        today = now.date()
+
+        # if cached on differnet day, its stale 
+        if cache_date != today:
+            return True
+
+        # cached today implies cache is fresh (nightly training at 2AM)
+        return False 
+
+
+
+    def clear_cache(self, user_id):
+        """
+        Clear cache for user specific data stored in memory 
+        """
+
+        if self.is_cache_stale(user_id):
+            print(f"Cache is stale for user {user_id}, clearing user model from cache")
+
+            if user_id in self._user_models:
+                del self._user_models[user_id]
+            if user_id in self.model_accuracy:
+                del self.model_accuracy[user_id]
+            if user_id in self._cache_date:
+                del self._cache_date[user_id]
+
+            gc.collect()
+
     
 
     def load_model_meta_data(self, user_id):


### PR DESCRIPTION
Fix bug with cache storing outdated model in memory, causing for our inference logic to reference outdated model and cause conflicts 