### PR TITLE
Sort Spending Analysis In Chronological Order and Add Filtering Capabiliteis

### DIFF
--- a/frontend/src/pages/BudgetSummaryPage.js
+++ b/frontend/src/pages/BudgetSummaryPage.js
@@ -17,6 +17,7 @@ const BudgetSummaryPage = () => {
     const itemsPerPage = 4; // 2 columns x 2 rows
     const [categoryTypeIds, setCategoryTypeIds] = useState([])
     const [sortedSummaries, setSortedSummaries] = useState([])
+    const [filterQuery, setFilterQuery] = useState("");
 
     const handleMonthYearClick = (summary) => {
         if (selectedSummary === summary) {
@@ -167,6 +168,17 @@ const BudgetSummaryPage = () => {
     const indexOfFirstItem = indexOfLastItem - itemsPerPage;
     const currentSummaries = sortedSummaries.slice(indexOfFirstItem, indexOfLastItem);
 
+    // variable to store filtered summaries based on user input
+    const filteredSummaries = sortedSummaries.filter(summary => {
+        let month = summary.id.monthYear.month.toLowerCase()
+        let year = summary.id.monthYear.year.toString()
+        let monthAndYear = month + " " + year;
+        console.log(monthAndYear)
+
+        return monthAndYear.startsWith(filterQuery.toLowerCase());
+
+    });
+
     return (
         <div className="flex flex-col min-h-screen bg-gradient-to-br from-gray-900 to-indigo-800">
             <FaArrowLeft
@@ -183,18 +195,38 @@ const BudgetSummaryPage = () => {
                 )}
                 <div className="flex justify-center items-center w-full h-1/5 mt-5 mb-8">
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full sm:w-2/5 xs:w-4/5">
-                        {currentSummaries.map((summary, index) => (
-                            <button
-                                key={index}
-                                className={`cursor-pointer text-white font-bold bg-indigo-900 rounded-lg shadow-md p-2 flex items-center justify-center space-x-2 w-full h-12 hover:bg-transparent hover:border hover:border-white hover:duration-500
+                        {filterQuery.length == 0 ? (
+                            // current page summaries if no user input provided
+                            currentSummaries.map((summary, index) => (
+                                <button
+                                    key={index}
+                                    className={`cursor-pointer text-white font-bold bg-indigo-900 rounded-lg shadow-md p-2 flex items-center justify-center space-x-2 w-full h-12 hover:bg-transparent hover:border hover:border-white hover:duration-500
                                     ${selectedSummary === summary ? 'border-2 border-white' : ''} xs:text-sm xs:h-10`}
-                                onClick={() => handleMonthYearClick(summary)}
-                            >
-                                {summary.id.monthYear.month} {summary.id.monthYear.year}
-                            </button>
-                        ))}
+                                    onClick={() => handleMonthYearClick(summary)}
+                                >
+                                    {summary.id.monthYear.month} {summary.id.monthYear.year}
+                                </button>
+                            ))) : (
+                            // filtered budget performances if user input added 
+                            filteredSummaries.map((summary, index) => (
+                                <button
+                                    key={index}
+                                    className={`cursor-pointer text-white font-bold bg-indigo-900 rounded-lg shadow-md p-2 flex items-center justify-center space-x-2 w-full h-12 hover:bg-transparent hover:border hover:border-white hover:duration-500
+                                    ${selectedSummary === summary ? 'border-2 border-white' : ''} xs:text-sm xs:h-10`}
+                                    onClick={() => handleMonthYearClick(summary)}
+                                >
+                                    {summary.id.monthYear.month} {summary.id.monthYear.year}
+                                </button>
+                            )))}
                     </div>
                 </div>
+                <input
+                    type="text"
+                    placeholder="Filter budget performances by month..."
+                    value={filterQuery}
+                    onChange={(e) => setFilterQuery(e.target.value)}
+                    className="mt-4 p-2 w-1/4 mb-5 rounded-md text-black xs:mt-2 xs:p-1 xs:text-sm"
+                />
                 <div className="flex justify-between w-2/5 mb-8 xs:w-4/5">
                     <div className="flex">
                         {currentPage > 1 && (

--- a/frontend/src/pages/BudgetSummaryPage.js
+++ b/frontend/src/pages/BudgetSummaryPage.js
@@ -16,6 +16,7 @@ const BudgetSummaryPage = () => {
     const [currentPage, setCurrentPage] = useState(1);
     const itemsPerPage = 4; // 2 columns x 2 rows
     const [categoryTypeIds, setCategoryTypeIds] = useState([])
+    const [sortedSummaries, setSortedSummaries] = useState([])
 
     const handleMonthYearClick = (summary) => {
         if (selectedSummary === summary) {
@@ -26,6 +27,22 @@ const BudgetSummaryPage = () => {
             setPrev(summary)
         }
     }
+
+    // Map months to numbers for easier comparison
+    const monthOrder = {
+        JANUARY: 1,
+        FEBRUARY: 2,
+        MARCH: 3,
+        APRIL: 4,
+        MAY: 5,
+        JUNE: 6,
+        JULY: 7,
+        AUGUST: 8,
+        SEPTEMBER: 9,
+        OCTOBER: 10,
+        NOVEMBER: 11,
+        DECEMBER: 12,
+    };
 
 
     const handleBackClick = () => {
@@ -109,6 +126,26 @@ const BudgetSummaryPage = () => {
         }
     }, [prev, selectedSummary])
 
+    // sort summaries based on latest month & year 
+    useEffect(() => {
+        if (!summaries) {
+            return;
+        }
+
+        let sorted = summaries.sort((a, b) => {
+
+            // if years are different, sort by descending 
+            if (b.id.monthYear.year != a.id.monthYear.year) {
+                return b.id.monthYear.year - a.id.monthYear.year;
+            }
+
+            // if years are same, sort by descending month 
+            return monthOrder[b.id.monthYear.month] - monthOrder[a.id.monthYear.month];
+        })
+        setSortedSummaries(sorted);
+
+    }, [summaries])
+
     /**
      * Functionality to convert to normal case
      *
@@ -128,7 +165,7 @@ const BudgetSummaryPage = () => {
     // Calculate the items for the current page
     const indexOfLastItem = currentPage * itemsPerPage;
     const indexOfFirstItem = indexOfLastItem - itemsPerPage;
-    const currentSummaries = summaries.slice(indexOfFirstItem, indexOfLastItem);
+    const currentSummaries = sortedSummaries.slice(indexOfFirstItem, indexOfLastItem);
 
     return (
         <div className="flex flex-col min-h-screen bg-gradient-to-br from-gray-900 to-indigo-800">


### PR DESCRIPTION
The following PR introduces the necessary functionality to be able to sort the Budget Performances for a user in chronological order, making it easy for users to quickly jump on and navigate to where their most recent budget performance is located. 

On top of this, this also introduces necessary functionality to be able to filter budget performances by month and year for quick lookups instead of searching. 