### PR TITLE
Resolve Cors Preflight Requests Being Blocked

### DIFF
--- a/backend/src/main/java/com/bavis/budgetapp/config/SecurityConfig.java
+++ b/backend/src/main/java/com/bavis/budgetapp/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable) // Disable CSRF
                 .authorizeHttpRequests((authz) ->
                         authz
+                                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Allow CORS preflight requests
                                 .requestMatchers("/auth/authenticate", "/auth/register", "/error", "/actuator/health").permitAll() // Allow registration/authentication endpoints
                                 .anyRequest().authenticated() // Authenticate all other requests
                 )


### PR DESCRIPTION
After Lets Encrypt certificate expiration, our CORS preflight requests are working only only on Desktop due to more aggressive caching (essentially working on accident). This is the resolution to this issue. 