### PR TITLE
Fix Issues With Logic Surrounding Checking If Transaction in Previous Month

### DIFF
--- a/backend/src/main/java/com/bavis/budgetapp/util/GeneralUtil.java
+++ b/backend/src/main/java/com/bavis/budgetapp/util/GeneralUtil.java
@@ -90,7 +90,12 @@ public class GeneralUtil {
         int currentYear = currentDate.getYear();
         int currentMonth =  currentDate.getMonthValue();
 
-        return currentYear == dateToCheck.getYear() && currentMonth - 1 == dateToCheck.getMonthValue(); // account for previous month
+        // Account for instance where current month is January
+        if (currentMonth != 1){
+            return currentYear == dateToCheck.getYear() && currentMonth - 1 == dateToCheck.getMonthValue(); // account for previous month
+        } else {
+            return dateToCheck.getYear() == currentYear - 1 && 12 == dateToCheck.getMonthValue();
+        }
     }
 
     /**

--- a/backend/src/test/java/com/bavis/budgetapp/controller/TransactionControllerTests.java
+++ b/backend/src/test/java/com/bavis/budgetapp/controller/TransactionControllerTests.java
@@ -136,6 +136,13 @@ public class TransactionControllerTests {
 
         int currentMonth = date.getMonthValue();
         int currentYear = date.getYear();
+
+        // account for issues where the current month is January of the new year
+        if (currentMonth == 1) {
+            currentMonth = 12;
+            currentYear -= 1;
+        }
+
         transactionThree = Transaction.builder()
                 .transactionId("54321EDCBA")
                 .date(LocalDate.of(currentYear, currentMonth - 1, 19)) // previous month transaction

--- a/backend/src/test/java/com/bavis/budgetapp/filter/TransactionFilterTests.java
+++ b/backend/src/test/java/com/bavis/budgetapp/filter/TransactionFilterTests.java
@@ -41,7 +41,15 @@ public class TransactionFilterTests {
 
     @Test
     void testPrevMonthTransactionFilters_shouldPass() {
-        sampleTransaction.setDate(LocalDate.now().minusMonths(1));
+        int monthToTest = LocalDate.now().getMonthValue() - 1;
+        int yearToTest = LocalDate.now().getYear();
+
+        // account for unit tests in January
+        LocalDate dateToTest = monthToTest == 0 ?
+                LocalDate.of(yearToTest - 1, 12, 19) :
+                LocalDate.of(yearToTest, yearToTest, 19);
+
+        sampleTransaction.setDate(dateToTest);
 
         List<Transaction> accounted = new ArrayList<>();
         boolean result = transactionFilters.prevMonthTransactionFilters(accounted).test(sampleTransaction);

--- a/backend/src/test/java/com/bavis/budgetapp/util/GeneralUtilTests.java
+++ b/backend/src/test/java/com/bavis/budgetapp/util/GeneralUtilTests.java
@@ -84,7 +84,14 @@ public class GeneralUtilTests {
     public  void testIsDateInPreviousMonth_Successful() {
         //Arrange date to be previous month
         LocalDate now = LocalDate.now();
-        LocalDate dateToTest = LocalDate.of(now.getYear(), now.getMonthValue() - 1, 19);
+
+        int yearToTest = now.getYear();
+        int monthToTest = now.getMonthValue() - 1;
+
+        // account for unit tests in January
+        LocalDate dateToTest = monthToTest == 0 ?
+                LocalDate.of(yearToTest - 1, 12, 19) :
+                LocalDate.of(yearToTest, yearToTest, 19);
 
         //Act
         boolean validity = GeneralUtil.isDateInPreviousMonth(dateToTest);


### PR DESCRIPTION
This logic was flawed when the current month was January. Instead of subtracting one from current month (i.e 0th month of 2026), we should instead check last month of last year (month 12 of 2025)  